### PR TITLE
Update 1_数据类型.md

### DIFF
--- a/docs/JavaBasics/1_数据类型.md
+++ b/docs/JavaBasics/1_数据类型.md
@@ -94,12 +94,18 @@ static {
 }
 ```
 
-编译器会在自动装箱过程调用 valueOf() 方法，因此多个 Integer 实例使用自动装箱来创建并且值相同，那么就会引用相同的对象。
+编译器会在自动装箱过程调用 valueOf() 方法，因此多个 Integer 实例使用自动装箱来创建并且值相同时，分两个情况讨论：
+
+- 如果数值范围在缓存池范围内，那么就会引用相同的对象；
+- 如果数值范围在缓存池范围外，那么就会引用不相同的对象。
 
 ```java
-Integer m = 123;
-Integer n = 123;
+Integer m = 127;
+Integer n = 127;
 System.out.println(m == n); // true
+Integer x = 128;
+Integer y = 128;
+System.out.println(x == y); // false
 ```
 
 \+ 不适用于 Integer 对象，首先 i，j 进行自动拆箱，然后数值相加，得到数值 80，进行自动装箱后，和 m 引用相同的对象。Integer 对象无法与数值直接进行比较，自动拆箱后转为数值 80，显然 80 == 80，输出 true。


### PR DESCRIPTION
自动装箱创建对象时，如果数值范围在缓存池范围外，那么就会引用不相同的对象